### PR TITLE
Add the "async" drone-trigger job

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,16 @@
+pipeline:
+
+  promote:
+    image: quay.io/ukhomeofficedigital/drone-trigger:latest
+    secrets:
+      - drone_token
+    drone_server: $${PROMOTIOM_SERVER}
+    drone_token: $${DRONE_TOKEN}
+    repo: $${PROMOTION_REPO}
+    number: $${DRONE_BUILD_NUMBER}
+    event: $${PROMOTION_EVENT}
+    deploy_to: $${DRONE_DEPLOY_TO}
+    params: "$${PROMOTION_PARAMS}"
+    when:
+      event: deployment
+      branch: master

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # drone-trigger-async
 A proxy drone-trigger allowing a full CD pipeline to be broken down into reusable chunks.
+
+## Usage
+The `drone.io` pipeline in this project is intended to be used by another [drone.io enabled] project. 
+The aim is to allow the dependent project to `drone-trigger` this pipeline, and complete its own pipeline, so that the dependent pipeline can trigger itself (by proxy of `drone-trigger-async`).
+
+## Acknowledgements
+ - [drone.io](http://docs.drone.io/)
+ - [drone-trigger](https://github.com/UKHomeOffice/drone-trigger)


### PR DESCRIPTION
This job (and indeed pipeline) is intended to be used by another [drone.io enabled] project. The aim is to allow the dependent project to `drone-trigger` this pipeline, and complete its own pipeline, so that the dependent pipeline can trigger itself by proxy of `drone-trigger-async`.